### PR TITLE
Make hash getting a replacable function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.test
 *~
 *.swp
+.idea/*


### PR DESCRIPTION
This PR is to make the point in the code where the hash is calculated an exported function that's a variable, so it can be swapped out as needed.

I investigated [using a patching approach](https://github.com/bouk/monkey) as well. I'm thinking we shouldn't use it for a couple of reasons - 1) it is very unusual in Go, and 2) it would be very difficult in this case.

Go doesn't tend to be patched since it is strongly typed. Forking is the more usual approach. Also, the unexported `auth` function is an instance method of an unexported `cn` object would be very difficult to get at.